### PR TITLE
Suppress type-limits warnings from GCC

### DIFF
--- a/mbed-client-libservice/ns_list.h
+++ b/mbed-client-libservice/ns_list.h
@@ -144,7 +144,9 @@ typedef struct ns_list {
 union \
 { \
     ns_list_t slist; \
+    NS_FUNNY_COMPARE_OK \
     NS_STATIC_ASSERT(link_offset <= UINT_FAST8_MAX, "link offset too large") \
+    NS_FUNNY_COMPARE_RESTORE \
     char (*offset)[link_offset + 1]; \
     entry_type *type; \
 }

--- a/mbed-client-libservice/ns_types.h
+++ b/mbed-client-libservice/ns_types.h
@@ -230,6 +230,17 @@ typedef int_fast32_t int_fast24_t;
 #define NS_FUNNY_INTPTR_RESTORE
 #endif
 
+/** \brief Pragma to suppress warnings about always true/false comparisons
+ */
+#if defined __GNUC__ && !defined __CC_ARM
+#define NS_FUNNY_COMPARE_OK         _Pragma("GCC diagnostic push") \
+                                    _Pragma("GCC diagnostic ignored \"-Wtype-limits\"")
+#define NS_FUNNY_COMPARE_RESTORE    _Pragma("GCC diagnostic pop")
+#else
+#define NS_FUNNY_COMPARE_OK
+#define NS_FUNNY_COMPARE_RESTORE
+#endif
+
 /** \brief Convert pointer to member to pointer to containing structure */
 #define NS_CONTAINER_OF(ptr, type, member) \
     ((type *) ((char *) (ptr) - offsetof(type, member)))


### PR DESCRIPTION
GCC produces a silly "comparison is always true" if an ns_list
has its link at offset 0, and UINT_FAST8_MAX is 0xFFFFFFFF,
and hence unsigned.

Suppress the warning.