### PR TITLE
libService: add new function to nsdynmem to query the stat structure

### DIFF
--- a/mbed-client-libservice/nsdynmemLIB.h
+++ b/mbed-client-libservice/nsdynmemLIB.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015 ARM Limited. All rights reserved.
+ * Copyright (c) 2014-2016 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the License); you may
  * not use this file except in compliance with the License.
@@ -96,6 +96,20 @@ extern void *ns_dyn_mem_temporary_alloc(int16_t alloc_size);
   * \return >0, Pointer to allocated data sector.
   */
 extern void *ns_dyn_mem_alloc(int16_t alloc_size);
+
+/**
+  * \brief Get pointer to the current mem_stat_t set via ns_dyn_mem_init.
+  *
+  * Get pointer to the statistics information, if one is set during the
+  * initialization. This may be useful for statistics collection purposes.
+  *
+  * Note: the caller may not modify the returned structure.
+  *
+  * \return NULL, no mem_stat_t was given on initialization
+  * \return !=0, Pointer to mem_stat_t.
+  */
+extern const mem_stat_t *ns_dyn_mem_get_mem_stat(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/source/nsdynmemLIB/nsdynmemLIB.c
+++ b/source/nsdynmemLIB/nsdynmemLIB.c
@@ -84,6 +84,15 @@ void ns_dyn_mem_init(uint8_t *heap, uint16_t h_size, void (*passed_fptr)(heap_fa
     heap_failure_callback = passed_fptr;
 }
 
+const mem_stat_t *ns_dyn_mem_get_mem_stat(void)
+{
+#ifndef STANDARD_MALLOC
+    return mem_stat_info_ptr;
+#else
+    return NULL;
+#endif
+}
+
 #ifndef STANDARD_MALLOC
 void dev_stat_update(mem_stat_update_t type, int16_t size)
 {

--- a/test/libService/unittest/nsdynmem/dynmemtest.cpp
+++ b/test/libService/unittest/nsdynmem/dynmemtest.cpp
@@ -41,6 +41,7 @@ TEST(dynmem, init)
     ns_dyn_mem_init(heap, size, &heap_fail_callback, &info);
     CHECK(info.heap_sector_size >= (size-4)); // Allow 4 bytes of alignment to happend
     CHECK(!heap_have_failed());
+    CHECK(ns_dyn_mem_get_mem_stat() == &info);
     free(heap);
 }
 


### PR DESCRIPTION
Add new call to query the memory statistics structure which is
given during the ns_dyn_mem_init() phase. This is useful for reporting
the memory usage statistics, as the heap init phase is board/platform
spesific and the stats structure given at that time may not be visible
to the testing code side.