### PR TITLE
Added mbed-trace submodule and adapted Makefile.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "source/mbed-trace"]
+	path = source/mbed-trace
+	url = git@github.com:ARMmbed/mbed-trace.git

--- a/.yotta_ignore
+++ b/.yotta_ignore
@@ -1,1 +1,2 @@
 test/*
+source/mbed-trace

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,14 @@ source/libip6string/stoip6.c \
 source/libList/ns_list.c \
 source/libTrace/ns_trace.c \
 source/nsdynmemLIB/nsdynmemLIB.c \
+source/mbed-trace/source/mbed_trace.c \
+source/mbed-trace/source/mbed_trace_ip6tos.c \
 
 LIB := libservice.a
-EXPORT_HEADERS := mbed-client-libservice
 
-include ../exported_rules.mk
+include ../../source/library_rules.mk
+
+.PHONY: export-headers
+export-headers:
+	cp -r --update mbed-client-libservice/* ../../libService
+	cp -r --update source/mbed-trace/mbed-trace ../../libService/


### PR DESCRIPTION
This is to allow compilation of applications in nanomesh-applications that depend on mbed-trace.

Next step would be to map calls made to old libTrace functions to the corresponding mbed-trace functions, and to adapt yotta build for this module to also build the submodule.