### PR TITLE
libTrace uses mbed-trace for tracing

### DIFF
--- a/mbed-client-libservice/ns_trace.h
+++ b/mbed-client-libservice/ns_trace.h
@@ -49,29 +49,27 @@ extern "C" {
 #define NS_TRACE_USE_MBED_TRACE
 #if defined(NS_TRACE_USE_MBED_TRACE)
 
-#if defined(HAVE_DEBUG)
-#ifndef FEA_TRACE_SUPPORT
+#if defined(HAVE_DEBUG) && !defined(FEA_TRACE_SUPPORT)
 #define FEA_TRACE_SUPPORT
-#endif
 #endif
 
 #include "mbed-trace/mbed_trace.h"
 
 
 /* Convert libTrace calls to mbed-trace calls */
-#define trace_init(void)                    mbed_trace_init()
-#define trace_free(void)                    mbed_trace_free()
+#define trace_init()                        mbed_trace_init()
+#define trace_free()                        mbed_trace_free()
 #define set_trace_config(config)            mbed_trace_config_set(config)
-#define get_trace_config(void)              mbed_trace_config_get()
+#define get_trace_config()                  mbed_trace_config_get()
 #define set_trace_prefix_function(pref_f)   mbed_trace_prefix_function_set(pref_f)
 #define set_trace_suffix_function(suffix_f) mbed_trace_suffix_function_set(suffix_f)
 #define set_trace_print_function(print_f)   mbed_trace_print_function_set(print_f)
 #define set_trace_cmdprint_function(printf) mbed_trace_cmdprint_function_set(printf)
 #define set_trace_exclude_filters(filters)  mbed_trace_exclude_filters_set(filters)
 #define set_trace_include_filters(filters)  mbed_trace_include_filters_set(filters)
-#define get_trace_exclude_filters(void)     mbed_trace_exclude_filters_get()
-#define get_trace_include_filters(void)     mbed_trace_include_filters_get()
-#define trace_last(void)                    mbed_trace_last()
+#define get_trace_exclude_filters()         mbed_trace_exclude_filters_get()
+#define get_trace_include_filters()         mbed_trace_include_filters_get()
+#define trace_last()                        mbed_trace_last()
 
 
 /* Definitions for the old functions with no equivalents in mbed-trace. These work without any special init.

--- a/mbed-client-libservice/ns_trace.h
+++ b/mbed-client-libservice/ns_trace.h
@@ -46,6 +46,74 @@
 extern "C" {
 #endif
 
+#define NS_TRACE_USE_MBED_TRACE
+#if defined(NS_TRACE_USE_MBED_TRACE)
+
+#if defined(HAVE_DEBUG)
+#ifndef FEA_TRACE_SUPPORT
+#define FEA_TRACE_SUPPORT
+#endif
+#endif
+
+#include "mbed-trace/mbed_trace.h"
+
+
+/* Convert libTrace calls to mbed-trace calls */
+#define trace_init(void)                    mbed_trace_init()
+#define trace_free(void)                    mbed_trace_free()
+#define set_trace_config(config)            mbed_trace_config_set(config)
+#define get_trace_config(void)              mbed_trace_config_get()
+#define set_trace_prefix_function(pref_f)   mbed_trace_prefix_function_set(pref_f)
+#define set_trace_suffix_function(suffix_f) mbed_trace_suffix_function_set(suffix_f)
+#define set_trace_print_function(print_f)   mbed_trace_print_function_set(print_f)
+#define set_trace_cmdprint_function(printf) mbed_trace_cmdprint_function_set(printf)
+#define set_trace_exclude_filters(filters)  mbed_trace_exclude_filters_set(filters)
+#define set_trace_include_filters(filters)  mbed_trace_include_filters_set(filters)
+#define get_trace_exclude_filters(void)     mbed_trace_exclude_filters_get()
+#define get_trace_include_filters(void)     mbed_trace_include_filters_get()
+#define trace_last(void)                    mbed_trace_last()
+
+
+/* Definitions for the old functions with no equivalents in mbed-trace. These work without any special init.
+ * */
+#if defined(FEA_TRACE_SUPPORT) || defined(HAVE_DEBUG) || (defined(YOTTA_CFG) && !defined(NDEBUG)) /*backward compatible*/
+#if defined  __GNUC__ || defined __CC_ARM
+/** obsolete function */
+void debugf(const char *fmt, ...) __attribute__ ((__format__(__printf__, 1, 2)));   //!< obsolete function
+void debug(const char *s);                                                          //!< obsolete function
+void debug_put(char c);                                                             //!< obsolete function
+void debug_hex(uint8_t x);                                                          //!< obsolete function
+void debug_int(int i);                                                              //!< obsolete function
+void printf_array(const void *buf, uint16_t len);                                   //!< obsolete function
+void printf_string(const void *buf, uint16_t len);                                  //!< obsolete function
+void printf_ipv6_address(const void *addr);                                         //!< obsolete function
+#else //__GNUC__ || __CC_ARM
+//obsolete functions:
+void debugf(const char *fmt, ...);
+void debug(const char *s);
+void debug_put(char c);
+void debug_hex(uint8_t x);
+void debug_int(int i);
+void printf_array(const void *buf, uint16_t len);
+void printf_string(const void *buf, uint16_t len);
+void printf_ipv6_address(const void *addr);
+#endif
+#else /*FEA_TRACE_SUPPORT*/
+// trace functionality not supported
+//obsolete
+#define debugf(...)                    ((void) 0)
+#define debug(s)                       ((void) 0)
+#define debug_put(c)                   ((void) 0)
+#define debug_hex(x)                   ((void) 0)
+#define debug_int(i)                   ((void) 0)
+#define printf_array(buf, len)         ((void) 0)
+#define printf_string(buf, len)        ((void) 0)
+#define printf_ipv6_address(addr)      ((void) 0)
+
+#endif /*FEA_TRACE_SUPPORT*/
+
+#else /* NS_TRACE_USE_MBED_TRACE */
+
 /** 3 upper bits are trace modes related,
     and 5 lower bits are trace level configuration */
 
@@ -313,6 +381,7 @@ void printf_ipv6_address(const void *addr);
 #define printf_ipv6_address(addr)      ((void) 0)
 
 #endif /*FEA_TRACE_SUPPORT*/
+#endif /* NS_TRACE_USE_MBED_TRACE */
 
 #ifdef __cplusplus
 }

--- a/source/libTrace/ns_trace.c
+++ b/source/libTrace/ns_trace.c
@@ -42,6 +42,8 @@
 #endif
 #endif
 
+#ifndef NS_TRACE_USE_MBED_TRACE
+
 #define VT100_COLOR_ERROR "\x1b[31m"
 #define VT100_COLOR_WARN  "\x1b[33m"
 #define VT100_COLOR_INFO  "\x1b[39m"
@@ -496,6 +498,7 @@ char *trace_array(const uint8_t *buf, uint16_t len)
     m_trace.tmp_data_ptr = wptr;
     return str;
 }
+#endif /* NS_TRACE_USE_MBED_TRACE */
 
 // rest of debug print functions will be obsolete and will be overridden with new trace interface..
 void debugf(const char *fmt, ...)


### PR DESCRIPTION
The following PRs are needed for this to work:
ARMmbed/sal-stack-nanostack-private#485
ARMmbed/nanomesh-libservice-root-private#28
ARMmbed/mbed-client-cliapp#211
ARMmbed/mbed-trace#25

@SeppoTakalo @kjbracey-arm @jupe @terhei 