### PR TITLE
fix yotta builds that don't define FEA_TRACE_SUPPORT

### DIFF
--- a/mbed-client-libservice/ns_trace.h
+++ b/mbed-client-libservice/ns_trace.h
@@ -49,7 +49,7 @@ extern "C" {
 #define NS_TRACE_USE_MBED_TRACE
 #if defined(NS_TRACE_USE_MBED_TRACE)
 
-#if defined(HAVE_DEBUG) && !defined(FEA_TRACE_SUPPORT)
+#if (defined(YOTTA_CFG_MBED_TRACE) || defined(HAVE_DEBUG)) && !defined(FEA_TRACE_SUPPORT)
 #define FEA_TRACE_SUPPORT
 #endif
 


### PR DESCRIPTION
@teetak01 @jupe 

@AnttiKauppila This is an issue in 3.5.2. This and publishing a newer version of mbed-trace should fix it.