### PR TITLE
Fix build on GCC older that 4.6.0

### DIFF
--- a/mbed-client-libservice/ns_types.h
+++ b/mbed-client-libservice/ns_types.h
@@ -247,7 +247,7 @@ typedef int_fast32_t int_fast24_t;
 
 /** \brief Pragma to suppress warnings about always true/false comparisons
  */
-#if defined __GNUC__ && !defined __CC_ARM
+#if defined __GNUC__ && NS_GCC_VERSION >= 40600 && !defined __CC_ARM
 #define NS_FUNNY_COMPARE_OK         _Pragma("GCC diagnostic push") \
                                     _Pragma("GCC diagnostic ignored \"-Wtype-limits\"")
 #define NS_FUNNY_COMPARE_RESTORE    _Pragma("GCC diagnostic pop")


### PR DESCRIPTION
GCC 4.6.0 added support to `#pragma GCC diagnostic push` and others that are used by `ns_types.h`