### PR TITLE
Disable traces from ns_nvm_helper

### DIFF
--- a/source/nvmHelper/ns_nvm_helper.c
+++ b/source/nvmHelper/ns_nvm_helper.c
@@ -5,7 +5,6 @@
 #include <string.h>
 #include <ns_types.h>
 #include <nsdynmemLIB.h>
-#define HAVE_DEBUG
 #include "ns_trace.h"
 #include "ns_list.h"
 #include "platform/arm_hal_nvm.h"


### PR DESCRIPTION
By default ns_nvm_helper traces are disabled.