### PR TITLE
Add dependency on mbed-trace

### DIFF
--- a/module.json
+++ b/module.json
@@ -11,6 +11,8 @@
   "extraIncludes": [
     "mbed-client-libservice"
   ],
-  "dependencies": {},
+  "dependencies": {
+      "mbed-trace": "ARMmbed/mbed-trace"
+  },
   "targetDependencies": {}
 }


### PR DESCRIPTION
'mbed-client-libservice/ns_trace.h' includes "mbed_trace.h", so this
module needs a dependency on ARMmbed/mbed-trace.