### PR TITLE
nsdynmemlib: silence IAR warnings caused by gotos skipping variable init

### DIFF
--- a/source/nsdynmemLIB/nsdynmemLIB.c
+++ b/source/nsdynmemLIB/nsdynmemLIB.c
@@ -236,7 +236,9 @@ static void *ns_mem_internal_alloc(ns_mem_book_t *book, const ns_mem_block_size_
         goto done;
     }
 
-    ns_mem_word_size_t block_data_size = -*block_ptr;
+    // Separate declaration from initialization to keep IAR happy as the gotos skip this block.
+    ns_mem_word_size_t block_data_size;
+    block_data_size = -*block_ptr;
     if (block_data_size >= (data_size + 2 + HOLE_T_SIZE)) {
         ns_mem_word_size_t hole_size = block_data_size - data_size - 2;
         ns_mem_word_size_t *hole_ptr;


### PR DESCRIPTION
The IAR 8.x gives two warnings in ns_mem_internal_alloc(),
where the gotos skip initialization of a variable. Silence these
by separating variable declaration from initialization.

Alternative way to fix these would be to add a scope, but that
looks a bit ugly too.

Warnings being silenced:
---8<---8<---8<---
[Warning] nsdynmemLIB.c@212,10: [Pe546]: transfer of control bypasses initialization of:
[Warning] nsdynmemLIB.c@236,0: [Pe546]: transfer of control bypasses initialization of:
[DEBUG] Return: 0
[DEBUG] Output:
[DEBUG] Output:           goto done;
[DEBUG] Output:           ^
[DEBUG] Output: "..nanostack-libservice/source/nsdynmemLIB/nsdynmemLIB.c",212  Warning[Pe546]: transfer of control bypasses initialization of:
[DEBUG] Output:             variable "block_data_size" (declared at line 239)
[DEBUG] Output:
[DEBUG] Output:           goto done;
[DEBUG] Output:           ^
[DEBUG] Output: "..nanostack-libservice/source/nsdynmemLIB/nsdynmemLIB.c",236  Warning[Pe546]: transfer of control bypasses initialization of:
[DEBUG] Output:             variable "block_data_size" (declared at line 239)