### PR TITLE
Add API to set temporary allocation heap limit

### DIFF
--- a/mbed-client-libservice/nsdynmemLIB.h
+++ b/mbed-client-libservice/nsdynmemLIB.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 ARM Limited. All rights reserved.
+ * Copyright (c) 2014-2018 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the License); you may
  * not use this file except in compliance with the License.
@@ -123,18 +123,18 @@ extern void *ns_dyn_mem_alloc(ns_mem_block_size_t alloc_size);
 extern const mem_stat_t *ns_dyn_mem_get_mem_stat(void);
 
 /**
-  * \brief Set temporary allocation memory fill factor.
+  * \brief Set amount of free heap that must be available for temporary memory allocation to succeed.
   *
-  * Temporary memory allocation will not allocate memory if heap fill factor is
-  * already reached.
+  * Temporary memory allocation will fail if system does not have defined amount of heap free.
   *
   * Note: the caller must set mem_stat_t structure in initialization.
   *
-  * \param reserved_heap_fill_factor percentage of reserved heap that can't be exceeded by temporary allocation
+  * \param free_heap_percentage percentage of total heap that must be free for temporary memory allocation. Set free_heap_amount to 0 when this percentage value.
+  * \param free_heap_amount Amount of free heap that must be free for temporary memory allocation. This value takes preference over percentage parameter value.
   *
   * \return 0 on success, <0 otherwise
   */
-extern int ns_dyn_mem_set_temporary_alloc_fill_factor(uint8_t reserved_heap_fill_factor);
+extern int ns_dyn_mem_set_temporary_alloc_free_heap_threshold(uint8_t free_heap_percentage, ns_mem_heap_size_t free_heap_amount);
 
 /**
   * \brief Init and set Dynamical heap pointer and length.
@@ -196,22 +196,23 @@ extern void *ns_mem_alloc(ns_mem_book_t *book, ns_mem_block_size_t alloc_size);
 extern const mem_stat_t *ns_mem_get_mem_stat(ns_mem_book_t *book);
 
 /**
-  * \brief Set temporary allocation heap fill factor.
+  * \brief Set amount of free heap that must be available for temporary memory allocation to succeed.
   *
-  * Temporary memory allocation will not allocate memory if heap fill factor is
-  * already reached.
+  * Temporary memory allocation will fail if system does not have defined amount of heap free.
   *
   * Note: the caller must set mem_stat_t structure in initialization.
   *
   * \param book Address of book keeping structure
-  * \param reserved_heap_fill_factor percentage of reserved heap that can't be exceeded by temporary allocation
+  * \param free_heap_percentage percentage of total heap that must be free for temporary memory allocation. Set free_heap_amount to 0 when using percentage value.
+  * \param free_heap_amount Amount of free heap that must be free for temporary memory allocation. This value takes preference over the percentage parameter value.
   *
   * \return 0 on success, <0 otherwise
   */
-extern int ns_mem_set_temporary_alloc_fill_factor(ns_mem_book_t *book, uint8_t reserved_heap_fill_factor);
+extern int ns_mem_set_temporary_alloc_free_heap_threshold(ns_mem_book_t *book, uint8_t free_heap_percentage, ns_mem_heap_size_t free_heap_amount);
 
 #ifdef __cplusplus
 }
 #endif
 #endif /* NSDYNMEMLIB_H_ */
+
 

--- a/mbed-client-libservice/nsdynmemLIB.h
+++ b/mbed-client-libservice/nsdynmemLIB.h
@@ -123,6 +123,20 @@ extern void *ns_dyn_mem_alloc(ns_mem_block_size_t alloc_size);
 extern const mem_stat_t *ns_dyn_mem_get_mem_stat(void);
 
 /**
+  * \brief Set temporary allocation memory fill factor.
+  *
+  * Temporary memory allocation will not allocate memory if heap fill factor is
+  * already reached.
+  *
+  * Note: the caller must set mem_stat_t structure in initialization.
+  *
+  * \param reserved_heap_fill_factor percentage of reserved heap that can't be exceeded by temporary allocation
+  *
+  * \return 0 on success, <0 otherwise
+  */
+extern int ns_dyn_mem_set_temporary_alloc_fill_factor(uint8_t reserved_heap_fill_factor);
+
+/**
   * \brief Init and set Dynamical heap pointer and length.
   *
   * \param heap_ptr Pointer to dynamically heap buffer
@@ -180,6 +194,21 @@ extern void *ns_mem_alloc(ns_mem_book_t *book, ns_mem_block_size_t alloc_size);
   * \return !=0, Pointer to mem_stat_t.
   */
 extern const mem_stat_t *ns_mem_get_mem_stat(ns_mem_book_t *book);
+
+/**
+  * \brief Set temporary allocation heap fill factor.
+  *
+  * Temporary memory allocation will not allocate memory if heap fill factor is
+  * already reached.
+  *
+  * Note: the caller must set mem_stat_t structure in initialization.
+  *
+  * \param book Address of book keeping structure
+  * \param reserved_heap_fill_factor percentage of reserved heap that can't be exceeded by temporary allocation
+  *
+  * \return 0 on success, <0 otherwise
+  */
+extern int ns_mem_set_temporary_alloc_fill_factor(ns_mem_book_t *book, uint8_t reserved_heap_fill_factor);
 
 #ifdef __cplusplus
 }

--- a/source/nsdynmemLIB/nsdynmemLIB.c
+++ b/source/nsdynmemLIB/nsdynmemLIB.c
@@ -41,12 +41,15 @@ struct ns_mem_book {
     void (*heap_failure_callback)(heap_fail_t);
     NS_LIST_HEAD(hole_t, link) holes_list;
     ns_mem_heap_size_t heap_size;
+    ns_mem_heap_size_t temporary_alloc_heap_limit;   /* Reserved heap limit for temporary alloc to succeed */
 };
 
 static ns_mem_book_t *default_book; // heap pointer for original "ns_" API use
 
 // size of a hole_t in our word units
 #define HOLE_T_SIZE ((ns_mem_word_size_t) ((sizeof(hole_t) + sizeof(ns_mem_word_size_t) - 1) / sizeof(ns_mem_word_size_t)))
+
+#define TEMPORARY_ALLOC_FILL_FACTOR 95  /* Default percentage of allocated heap that temporary allocation can't exceed */
 
 static NS_INLINE hole_t *hole_from_block_start(ns_mem_word_size_t *start)
 {
@@ -124,6 +127,7 @@ ns_mem_book_t *ns_mem_init(void *heap, ns_mem_heap_size_t h_size,
         memset(book->mem_stat_info_ptr, 0, sizeof(mem_stat_t));
         book->mem_stat_info_ptr->heap_sector_size = book->heap_size;
     }
+    book->temporary_alloc_heap_limit = book->heap_size/100 * TEMPORARY_ALLOC_FILL_FACTOR;
 #endif
     //There really is no support to standard malloc in this library anymore
     book->heap_failure_callback = passed_fptr;
@@ -138,6 +142,31 @@ const mem_stat_t *ns_mem_get_mem_stat(ns_mem_book_t *heap)
 #else
     return NULL;
 #endif
+}
+
+int ns_mem_set_temporary_alloc_fill_factor(ns_mem_book_t *book, uint8_t reserved_heap_fill_factor)
+{
+#ifndef STANDARD_MALLOC
+    if (reserved_heap_fill_factor < 10 || reserved_heap_fill_factor > 100) {
+        // illegal percentages
+        return -1;
+    }
+
+    if (!book || !book->mem_stat_info_ptr) {
+        // no book or mem_stats
+        return -2;
+    }
+    book->temporary_alloc_heap_limit = book->heap_size/100 * reserved_heap_fill_factor;
+
+    return 0;
+#else
+    return -3;
+#endif
+}
+
+int ns_dyn_mem_set_temporary_alloc_fill_factor(uint8_t reserved_heap_fill_factor)
+{
+    return ns_mem_set_temporary_alloc_fill_factor(default_book, reserved_heap_fill_factor);
 }
 
 #ifndef STANDARD_MALLOC
@@ -200,6 +229,13 @@ static void *ns_mem_internal_alloc(ns_mem_book_t *book, const ns_mem_block_size_
         /* We can not do anything except return NULL because we can't find book
            keeping block */
         return NULL;
+    }
+
+    if (book->mem_stat_info_ptr && direction == 1) {
+        if (book->mem_stat_info_ptr->heap_sector_allocated_bytes > book->temporary_alloc_heap_limit) {
+            /* Not enough heap for temporary memory allocation */
+            return NULL;
+        }
     }
 
     ns_mem_word_size_t *block_ptr = NULL;

--- a/test/libService/unittest/nsdynmem/dynmemtest.cpp
+++ b/test/libService/unittest/nsdynmem/dynmemtest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 ARM Limited. All rights reserved.
+ * Copyright (c) 2015-2018 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the License); you may
  * not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ TEST(dynmem, init)
     mem_stat_t info;
     reset_heap_error();
     ns_dyn_mem_init(heap, size, &heap_fail_callback, &info);
-    CHECK(info.heap_sector_size >= (size-64));
+    CHECK(info.heap_sector_size >= (size-72));
     CHECK(!heap_have_failed());
     CHECK(ns_dyn_mem_get_mem_stat() == &info);
     free(heap);
@@ -50,7 +50,7 @@ TEST(dynmem, different_sizes)
         mem_stat_t info;
         uint8_t *heap = (uint8_t*)malloc(size);
         ns_dyn_mem_init(heap, size, &heap_fail_callback, &info);
-        CHECK(info.heap_sector_size >= (size-64));
+        CHECK(info.heap_sector_size >= (size-72));
         CHECK(!heap_have_failed());
         CHECK(ns_dyn_mem_alloc(10));
         free(heap);
@@ -68,7 +68,7 @@ TEST(dynmem, diff_alignment)
     for (int i=0; i<16; i++) {
         ptr++; size--;
         ns_dyn_mem_init(ptr, size, &heap_fail_callback, &info);
-        CHECK(info.heap_sector_size >= (size-64));
+        CHECK(info.heap_sector_size >= (size-72));
         CHECK(!heap_have_failed());
     }
     free(heap);
@@ -273,7 +273,7 @@ TEST(dynmem, diff_sizes)
     ns_dyn_mem_init(heap, size, &heap_fail_callback, &info);
     CHECK(!heap_have_failed());
     int i;
-    for (i=1; i<(size-64); i++) {
+    for (i=1; i<(size-72); i++) {
         p = ns_dyn_mem_temporary_alloc(i);
         CHECK(p);
         ns_dyn_mem_free(p);

--- a/test/libService/unittest/nsdynmem/dynmemtest.cpp
+++ b/test/libService/unittest/nsdynmem/dynmemtest.cpp
@@ -136,6 +136,81 @@ TEST(dynmem, ns_dyn_mem_temporary_alloc)
     free(heap);
 }
 
+TEST(dynmem, ns_dyn_mem_temporary_alloc_with_heap_threshold)
+{
+    uint16_t size = 1000;
+    mem_stat_t info;
+    void *p1, *p2;
+    int ret_val;
+    uint8_t *heap = (uint8_t*)malloc(size);
+    CHECK(NULL != heap);
+    reset_heap_error();
+    ns_dyn_mem_init(heap, size, &heap_fail_callback, &info);
+    CHECK(!heap_have_failed());
+
+    // test1: temporary alloc will fail if there is less than 5% heap free
+    p1 = ns_dyn_mem_temporary_alloc((size-72)*0.96);
+    CHECK(!heap_have_failed());
+    CHECK(p1);
+    p2 = ns_dyn_mem_temporary_alloc((size-72)*0.02);
+    CHECK(p2 == NULL);
+    CHECK(!heap_have_failed());
+    CHECK(info.heap_alloc_fail_cnt == 1);
+
+    // Test2, disable threshold feature and try p2 allocation again
+    ns_dyn_mem_set_temporary_alloc_free_heap_threshold(0, 0);
+    p2 = ns_dyn_mem_temporary_alloc((size-72)*0.02);
+    CHECK(!heap_have_failed());
+    CHECK(p2);
+    ns_dyn_mem_free(p1);
+    ns_dyn_mem_free(p2);
+    CHECK(info.heap_alloc_fail_cnt == 1);
+    CHECK(info.heap_sector_alloc_cnt == 0);
+
+    // Test3, enable feature by free heap percentage
+    ns_dyn_mem_set_temporary_alloc_free_heap_threshold(40, 0);
+    p1 = ns_dyn_mem_temporary_alloc((size-72)*0.65);
+    CHECK(p1);
+    p2 = ns_dyn_mem_temporary_alloc((size-72)*0.10);
+    CHECK(p2==NULL);
+    ns_dyn_mem_free(p1);
+    CHECK(!heap_have_failed());
+    CHECK(info.heap_alloc_fail_cnt == 2);
+    CHECK(info.heap_sector_alloc_cnt == 0);
+
+    // Test4, enable feature by free heap amount
+    ns_dyn_mem_set_temporary_alloc_free_heap_threshold(0, 200);
+    p1 = ns_dyn_mem_temporary_alloc(size-72-100 /*828 bytes */);
+    CHECK(p1);
+    p2 = ns_dyn_mem_temporary_alloc(1);
+    CHECK(p2==NULL);
+    ns_dyn_mem_free(p1);
+
+    // Test5, illegal API parameters
+    ret_val = ns_dyn_mem_set_temporary_alloc_free_heap_threshold(0, size/2);
+    CHECK(ret_val==-2);
+    ret_val = ns_dyn_mem_set_temporary_alloc_free_heap_threshold(0, size*2);
+    CHECK(ret_val==-2);
+    ret_val = ns_dyn_mem_set_temporary_alloc_free_heap_threshold(51, 0);
+    CHECK(ret_val==-2);
+    ret_val = ns_dyn_mem_set_temporary_alloc_free_heap_threshold(255, 0);
+    CHECK(ret_val==-2);
+
+    CHECK(!heap_have_failed());
+    CHECK(info.heap_alloc_fail_cnt == 3);
+    CHECK(info.heap_sector_alloc_cnt == 0);
+    free(heap);
+
+    // Test6, feature is disabled if info is not set
+    heap = (uint8_t*)malloc(size);
+    CHECK(NULL != heap);
+    ns_dyn_mem_init(heap, size, &heap_fail_callback, NULL);
+    ret_val = ns_dyn_mem_set_temporary_alloc_free_heap_threshold(0, 0);
+    CHECK(ret_val==-1);
+    CHECK(!heap_have_failed());
+    free(heap);
+}
+
 TEST(dynmem, test_both_allocs_with_hole_usage) {
     uint16_t size = 112;
     mem_stat_t info;

--- a/test/libService/unittest/stubs/ns_list_stub.c
+++ b/test/libService/unittest/stubs/ns_list_stub.c
@@ -1,5 +1,17 @@
 /*
  * Copyright (c) 2015 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #define NS_LIST_FN extern

--- a/test/libService/unittest/stubs/nsdynmemLIB_stub.c
+++ b/test/libService/unittest/stubs/nsdynmemLIB_stub.c
@@ -1,6 +1,19 @@
 /*
- * Copyright (c) 2014-2015 ARM Limited. All rights reserved.
+ * Copyright (c) 2016, 2018 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 #include "nsdynmemLIB_stub.h"
 #include <stdint.h>
 #include <string.h>
@@ -12,11 +25,11 @@
 
 nsdynmemlib_stub_data_t nsdynmemlib_stub;
 
-void ns_dyn_mem_init(uint8_t *heap, uint16_t h_size, void (*passed_fptr)(heap_fail_t), mem_stat_t *info_ptr)
+void ns_dyn_mem_init(void *heap, ns_mem_heap_size_t h_size, void (*passed_fptr)(heap_fail_t), mem_stat_t *info_ptr)
 {
 }
 
-void *ns_dyn_mem_alloc(int16_t alloc_size)
+void *ns_dyn_mem_alloc(ns_mem_block_size_t alloc_size)
 {
     if (nsdynmemlib_stub.returnCounter > 0)
     {
@@ -29,7 +42,7 @@ void *ns_dyn_mem_alloc(int16_t alloc_size)
     }
 }
 
-void *ns_dyn_mem_temporary_alloc(int16_t alloc_size)
+void *ns_dyn_mem_temporary_alloc(ns_mem_block_size_t alloc_size)
 {
     if (nsdynmemlib_stub.returnCounter > 0)
     {

--- a/test/libService/unittest/stubs/nsdynmemLIB_stub.h
+++ b/test/libService/unittest/stubs/nsdynmemLIB_stub.h
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) 2015 ARM Limited. All rights reserved.
+ * Copyright (c) 2016, 2018 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #ifndef __NSDYNMEMLIB_STUB_H__
 #define __NSDYNMEMLIB_STUB_H__

--- a/test/libService/unittest/stubs/platform_nvm_stub.c
+++ b/test/libService/unittest/stubs/platform_nvm_stub.c
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) 2016, ARM Limited, All Rights Reserved.
+ * Copyright (c) 2016 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "ns_types.h"


### PR DESCRIPTION
Add new API to set allocated heap limit that temporary allocation
can't exceed. When limit is reached then temporary memory allocation
will fail. By default temporary allocation will fail if 95% of the
heap is already allocated.