### PR TITLE
Avoid memcmp(x, NULL, 0)

### DIFF
--- a/source/libBits/common_functions.c
+++ b/source/libBits/common_functions.c
@@ -35,7 +35,7 @@ bool bitsequal(const uint8_t *a, const uint8_t *b, uint_fast8_t bits)
     uint_fast8_t bytes = bits / 8;
     bits %= 8;
 
-    if (memcmp(a, b, bytes)) {
+    if (bytes && memcmp(a, b, bytes)) {
         return false;
     }
 


### PR DESCRIPTION
libBits' comparison and copying operations are assumed to do the right
thing when passed a NULL pointer and zero length by various bits of
code.

It is not legal to call any standard C library function like memcmp or
memcpy with an invalid pointer, even if length is 0.

Copy code avoids that, but bitsequal could call memcmp(x, NULL, 0). Add
an extra condition to avoid this.

Spotted while inspecting Coverity reports (although it wasn't directly
related to the memcmp call, but a false positive on another path).