### PR TITLE
Sync with Mbed OS libservice

### DIFF
--- a/mbed-client-libservice/ns_types.h
+++ b/mbed-client-libservice/ns_types.h
@@ -121,7 +121,15 @@ typedef int_fast32_t int_fast24_t;
 #define alignas(n) __align(n)
 #define __alignas_is_defined 1
 #elif (defined __STDC_VERSION__ && __STDC_VERSION__ >= 201112L) || (defined __cplusplus && __cplusplus >= 201103L)
-#include <stdalign.h>
+# if defined __ARMCC_VERSION && __ARMCC_VERSION < 6120000
+    /* Workaround for Arm Compiler versions prior to 6.12 */
+#   if !defined __cplusplus
+#     define alignas _Alignas
+#   endif
+#   define __alignas_is_defined 1
+# else
+#   include <stdalign.h>
+# endif
 #elif defined __GNUC__
 #define alignas(n) __attribute__((__aligned__(n)))
 #define __alignas_is_defined 1


### PR DESCRIPTION
Sync content of `mbed-os/features/frameworks/nanostack-libservice/mbed-client-libservice` with this repository.