### PR TITLE
Add flag to indicate this library's presence

### DIFF
--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -1,3 +1,6 @@
 {
-    "name": "nanostack-libservice"
+    "name": "nanostack-libservice",
+    "config": {
+        "present": 1
+    }
 }


### PR DESCRIPTION
Upstreamed from https://github.com/ARMmbed/mbed-os/pull/13649

`mbed-trace`'s IPv6 tracing [depends](https://github.com/ARMmbed/mbed-trace/blob/81e95acee7b35cb1065ae29a6393a928b5e6663c/source/mbed_trace.c#L24-L32) on this library, but we can't always assume this exists because Mbed OS's bare metal profile has features not enabled by default.

This PR adds a config `present` which translates to the macro `MBED_CONF_NANOSTACK_LIBSERVICE_PRESENT` that mbed-trace can check.